### PR TITLE
remove proxy loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Misskey is a decentralized microblogging platform. Since it exists within the Fediverse (a universe where various social media platforms are organized), it is mutually linked with other social media platforms.
 
 
-**Shipped version:** 12.96.1~ynh1
+**Shipped version:** 12.96.1~ynh2
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Misskey est une plateforme de microblogging décentralisée. Puisqu'il existe au sein du Fediverse (un univers où diverses plateformes de médias sociaux sont organisées), il est mutuellement lié à d'autres plateformes de médias sociaux.
 
-**Version incluse :** 12.96.1~ynh1
+**Version incluse :** 12.96.1~ynh2
 
 
 

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -139,7 +139,7 @@ id: "aid"
 #  port: 514
 
 # Proxy for HTTP/HTTPS
-proxy: http://127.0.0.1:__PORT__
+#proxy: http://127.0.0.1:3128
 
 #proxyBypassHosts: [
 #  'example.com',

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "en": "Microblogging platform",
     "fr": "Platforme de Microblogging"
   },
-  "version": "12.96.1~ynh1",
+  "version": "12.96.1~ynh2",
   "url": "https://join.misskey.page/en/",
   "upstream": {
         "license": "AGPL-3.0",


### PR DESCRIPTION
Currently outgoing connections fail with:

`FetchError: request to [...] failed, reason: socket hang up`

I removed the proxy directive. I believe this is a socks proxy that misskey uses for outgoing connections.
Setting this to the ip and port of misskey would result in all outgoing connections being looped back to the application itself.