### PR TITLE
Update upgrade - Ensure downward compatibility

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,6 +30,15 @@ port=$(ynh_app_setting_get --app=$app --key=port)
 upgrade_type=$(ynh_check_app_version_changed)
 
 #=================================================
+# ENSURE DOWNWARD COMPATIBILITY
+#=================================================
+
+if ynh_compare_current_package_version --comparison lt --version 12.105.0~ynh1
+then
+	ynh_die --message="Sorry, this version is not upgradable to the latest version :("
+fi
+
+#=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 ynh_script_progression --message="Backing up the app before upgrading (may take a while)..." --weight=1


### PR DESCRIPTION
## Ensure downward compatibility

## Problem

- *Misskey fails to update if current package version is lower than 12.105.0~ynh1*

## Solution

- *The update terminates with an error message.*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

Resolves https://github.com/YunoHost-Apps/misskey_ynh/issues/66
