### PR TITLE
instance.actor gets admin rights

### DIFF
--- a/conf/default.yml
+++ b/conf/default.yml
@@ -138,7 +138,7 @@ id: 'aid'
 #proxyRemoteFiles: true
 
 # Sign to ActivityPub GET request (default: false)
-signToActivityPubGet: true
+# signToActivityPubGet: true
 
 #allowedPrivateNetworks: [
 #  '127.0.0.1/32'


### PR DESCRIPTION
System account `instance.actor` becomes user No. 1 (admin)

## Problem

If the `instance.actor` account is created first due to installation procedure, this account becomes admin rights instead of first created user. 

## Solution

Commenting out `signToActivityPubGet: true` in `misskey_ynh/conf/default.yml`

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

